### PR TITLE
RTC-12779: Update maestro types and payloads

### DIFF
--- a/chat-model/src/main/resources/canon/chat.json
+++ b/chat-model/src/main/resources/canon/chat.json
@@ -1119,6 +1119,7 @@
       "MaestroPayloadType": {
         "type": "string",
         "enum": [
+          "MaestroPayload",
           "D9ProvisioningPayload",
           "activateRoomPayload",
           "reactivateRoomPayload",
@@ -1150,8 +1151,10 @@
           "xPodIMStateChangeMaestroPayload",
           "requestContentExportKeyMaestroPayload",
           "updateStreamMembershipMetadataPayload",
-          "MaestroPayload",
-          "malwareScanUpdatePayload"
+          "malwareScanUpdatePayload",
+          "userDataRemovalRequestPayload",
+          "reactionDetailsPayload",
+          "cloud9EventPayload"
         ]
       },
       "MaestroPayloadContainer": {
@@ -1480,7 +1483,22 @@
           "MEETING_PARTICIPANT_RECORDING_START",
           "MEETING_PARTICIPANT_RECORDING_STOP",
           "MEETING_PARTICIPANT_RECORDING_FAILED",
-          "MESSAGE_SUPPRESSION_REQUEST"
+
+          "MESSAGE_SUPPRESSION_REQUEST",
+
+          "USER_DATA_REMOVAL_REQUEST",
+
+          "DENY_JOIN_ROOM_REQUEST",
+
+          "STREAM_INVITATION",
+
+          "REACTION_DETAILS",
+
+          "SDL_JOIN",
+          "SDL_JOINED",
+          "SDL_LEAVE",
+
+          "CLOUD9_EVENT"
         ]
       },
 			"MaestroMessage": {


### PR DESCRIPTION
Updating the list of maestro event types and payloads to work with forwarder. I am updating them because I am adding a new maestro type, and it fails to be handled by the forwarder and never reaches DF2.

They are extracted from:
https://github.com/SymphonyOSF/SymphonyLibrary/blob/master/msgpack/src/main/java/com/symphony/msgpack/internal/types/MaestroEventType.java#L161-L173
https://github.com/SymphonyOSF/SymphonyLibrary/blob/master/msgpack/src/main/java/com/symphony/msgpack/internal/types/maestropayload/MaestroPayload.java#L54-L56

Please check this search about messages that were sent for these types:
https://symphony.splunkcloud.com/en-US/app/search/search?sid=1653641394.526154