### PR TITLE
CES-21658: expose missing presence properties

### DIFF
--- a/chat-model/src/main/resources/canon/chat.json
+++ b/chat-model/src/main/resources/canon/chat.json
@@ -270,6 +270,13 @@
           },
           "idle": {
             "type": "boolean"
+          },
+          "category": {
+            "type": "string"
+          },
+          "resetAt": {
+            "type": "integer",
+            "format": "int64"
           }
         }
       },


### PR DESCRIPTION
As part of https://perzoinc.atlassian.net/browse/CES-21658, Federation would like to consume `PresenceChangeMessage` from forwarder queue, and the important fields `category` and `resetAt` are actually missing from the client grammar.